### PR TITLE
✨ PostList 및 PostCard 컴포넌트 UI 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Routes, Route } from 'react-router-dom';
 import MainPage from './pages/MainPage';
 import RegisterPage from './pages/RegisterPage';
 import LoginPage from './pages/LoginPage';
+import ListPage from './pages/ListPage';
 
 function App() {
   return (
@@ -10,6 +11,7 @@ function App() {
       <Route index element={<MainPage />} />
       <Route path="/register" element={<RegisterPage />} />
       <Route path="/login" element={<LoginPage />} />
+      <Route path="/list" element={<ListPage />} />
     </Routes>
   );
 }

--- a/src/components/atoms/CopyButton.tsx
+++ b/src/components/atoms/CopyButton.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { Fade, IconButton, Tooltip } from '@mui/material';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+
+interface CopyButtonProps {
+  text: string;
+}
+
+function CopyButton({ text }: CopyButtonProps) {
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  const handleCopyClipBoard = async (text: string) => {
+    try {
+      if (text) await navigator.clipboard.writeText(text);
+      setShowTooltip(true);
+      setTimeout(() => setShowTooltip(false), 1500);
+    } catch (error) {
+      alert('복사 실패!');
+    }
+  };
+
+  return (
+    <Tooltip
+      title="클립보드에 복사됨"
+      open={showTooltip}
+      placement="bottom"
+      disableFocusListener
+      disableHoverListener
+      disableTouchListener
+      TransitionComponent={Fade}
+      TransitionProps={{ timeout: 700 }}
+    >
+      <IconButton
+        size="small"
+        onClick={() => {
+          handleCopyClipBoard(text);
+        }}
+      >
+        <ContentCopyIcon fontSize="small" />
+      </IconButton>
+    </Tooltip>
+  );
+}
+
+export default CopyButton;

--- a/src/components/atoms/PostCard.tsx
+++ b/src/components/atoms/PostCard.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import CopyButton from './CopyButton';
+import { Post } from '../../types/post';
+
+import {
+  Box,
+  Card,
+  CardMedia,
+  CardContent,
+  Typography,
+  IconButton,
+} from '@mui/material';
+import { BookmarkOutlined } from '@mui/icons-material';
+import BookmarkIcon from '@mui/icons-material/Bookmark';
+import RoomOutlinedIcon from '@mui/icons-material/RoomOutlined';
+
+interface AddressProps {
+  fullAddress: string;
+}
+/**
+ * Post카드 하단의 주소영역 컴포넌트
+ */
+function Address({ fullAddress }: AddressProps) {
+  const getSimpleAddress = (fullAddress: string) => {
+    if (fullAddress) {
+      return fullAddress.split(' ').slice(1, 4).join(' ');
+    } else {
+      return '';
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: 0.5,
+        alignItems: 'center',
+      }}
+    >
+      <Box>
+        <Typography variant="body2" color="text.secondary">
+          <RoomOutlinedIcon fontSize="small" />
+        </Typography>
+      </Box>
+      <Box marginRight={0.5}>
+        <Typography variant="body2" color="text.secondary">
+          {getSimpleAddress(fullAddress)}
+        </Typography>
+      </Box>
+      <Box>
+        <CopyButton text={fullAddress} />
+      </Box>
+    </Box>
+  );
+}
+
+interface PostCardProps {
+  post: Post;
+  handleBookmarkClick: any;
+}
+
+function PostCard({ post, handleBookmarkClick }: PostCardProps) {
+  const { id, category, title, fullAddress, thumbnail, isBookmarked } = post;
+
+  return (
+    <Card sx={{ position: 'relative', borderRadius: '10px' }}>
+      {/* 북마크 버튼 */}
+      <IconButton
+        aria-label="settings"
+        sx={{ position: 'absolute', right: 0 }}
+        onClick={() => handleBookmarkClick(id)}
+      >
+        {isBookmarked ? (
+          <BookmarkIcon
+            sx={{ stroke: '#ffffff', strokeWidth: 1, color: '#FEE500' }}
+          />
+        ) : (
+          <BookmarkOutlined sx={{ stroke: '#ffffff', strokeWidth: 1 }} />
+        )}
+      </IconButton>
+      <CardMedia sx={{ height: 160 }} image={thumbnail} title={title} />
+      <CardContent>
+        <Typography
+          gutterBottom
+          variant="subtitle1"
+          component="div"
+          css={textOverflowStyle('2')}
+        >
+          {`[${category}]`} {`${title}`}
+        </Typography>
+        <Address fullAddress={fullAddress} />
+      </CardContent>
+    </Card>
+  );
+}
+
+export default PostCard;
+
+/**
+ *
+ * @param line ${line}줄까지만 보여주고 그것을 넘는 문장은 말줄임표 처리를 해주는 스타일
+ */
+const textOverflowStyle = (line: string) => css`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: ${line};
+  -webkit-box-orient: vertical;
+`;

--- a/src/components/blocks/PostList.tsx
+++ b/src/components/blocks/PostList.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import PostCard from '../atoms/PostCard';
+import { Grid } from '@mui/material';
+import { Post } from '../../types/post';
+
+interface PostListProps {
+  posts: Post[];
+  handleBookmarkClick: any;
+}
+
+function PostList({ posts, handleBookmarkClick }: PostListProps) {
+  return (
+    <Grid container spacing={{ xs: 2, md: 3 }}>
+      {posts.map((post) => (
+        <Grid item xs={12} sm={6} md={4} lg={3} key={post.id.toString()}>
+          <PostCard post={post} handleBookmarkClick={handleBookmarkClick} />
+        </Grid>
+      ))}
+    </Grid>
+  );
+}
+
+export default PostList;

--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -1,0 +1,124 @@
+import React, { useEffect, useState } from 'react';
+import { Container } from '@mui/material';
+import PostList from '../components/blocks/PostList';
+import { Post } from '../types/post';
+
+function ListPage() {
+  const [posts, setPosts] = useState<Post[]>([]);
+
+  useEffect(() => {
+    const data = [
+      {
+        id: 1,
+        category: '식당',
+        title: `코엑스 근처 레스토랑 '오크우드 프리미어 코엑스 센터
+      오크레스토랑' 모임 장소로 추천합니다!`,
+        fullAddress:
+          '서울 강남구 테헤란로87길 46 오크우드 호텔 5층 오크레스토랑',
+        thumbnail:
+          'https://p0.pikist.com/photos/697/852/pool-swimming-pool-water-blue-turquoise-texture-clear-wet-ripples.jpg',
+        isBookmarked: true,
+      },
+      {
+        id: 2,
+        category: '카페',
+        title: `디저트가 맛있는 서울 카페`,
+        fullAddress: '서울 성동구 서울숲9길 3 B1~2F',
+        thumbnail:
+          'https://p0.pikist.com/photos/697/852/pool-swimming-pool-water-blue-turquoise-texture-clear-wet-ripples.jpg',
+        isBookmarked: false,
+      },
+      {
+        id: 3,
+        category: '공원',
+        title: `용산 가족공원 나들이~ 문화재와 예쁜 꽃들을 함께 볼 수 있어요`,
+        fullAddress: '서울 용산구 서빙고로 137 국립중앙박물관',
+        thumbnail:
+          'https://p0.pikist.com/photos/697/852/pool-swimming-pool-water-blue-turquoise-texture-clear-wet-ripples.jpg',
+        isBookmarked: false,
+      },
+      {
+        id: 4,
+        category: '카페',
+        title: `디저트가 맛있는 서울 카페`,
+        fullAddress: '서울 성동구 서울숲9길 3 B1~2F',
+        thumbnail:
+          'https://p0.pikist.com/photos/697/852/pool-swimming-pool-water-blue-turquoise-texture-clear-wet-ripples.jpg',
+        isBookmarked: false,
+      },
+      {
+        id: 5,
+        category: '카페',
+        title: `디저트가 맛있는 서울 카페`,
+        fullAddress: '서울 성동구 서울숲9길 3 B1~2F',
+        thumbnail:
+          'https://p0.pikist.com/photos/697/852/pool-swimming-pool-water-blue-turquoise-texture-clear-wet-ripples.jpg',
+        isBookmarked: false,
+      },
+      {
+        id: 6,
+        category: '카페',
+        title: `디저트가 맛있는 서울 카페`,
+        fullAddress: '서울 성동구 서울숲9길 3 B1~2F',
+        thumbnail:
+          'https://p0.pikist.com/photos/697/852/pool-swimming-pool-water-blue-turquoise-texture-clear-wet-ripples.jpg',
+        isBookmarked: true,
+      },
+      {
+        id: 7,
+        category: '카페',
+        title: `디저트가 맛있는 서울 카페`,
+        fullAddress: '서울 성동구 서울숲9길 3 B1~2F',
+        thumbnail:
+          'https://p0.pikist.com/photos/697/852/pool-swimming-pool-water-blue-turquoise-texture-clear-wet-ripples.jpg',
+        isBookmarked: false,
+      },
+      {
+        id: 8,
+        category: '카페',
+        title: `디저트가 맛있는 서울 카페`,
+        fullAddress: '서울 성동구 서울숲9길 3 B1~2F',
+        thumbnail:
+          'https://p0.pikist.com/photos/697/852/pool-swimming-pool-water-blue-turquoise-texture-clear-wet-ripples.jpg',
+        isBookmarked: false,
+      },
+      {
+        id: 9,
+        category: '카페',
+        title: `디저트가 맛있는 서울 카페`,
+        fullAddress: '서울 성동구 서울숲9길 3 B1~2F',
+        thumbnail:
+          'https://p0.pikist.com/photos/697/852/pool-swimming-pool-water-blue-turquoise-texture-clear-wet-ripples.jpg',
+        isBookmarked: false,
+      },
+      {
+        id: 10,
+        category: '카페',
+        title: `디저트가 맛있는 서울 카페`,
+        fullAddress: '서울 성동구 서울숲9길 3 B1~2F',
+        thumbnail:
+          'https://p0.pikist.com/photos/697/852/pool-swimming-pool-water-blue-turquoise-texture-clear-wet-ripples.jpg',
+        isBookmarked: false,
+      },
+    ];
+    setPosts(data);
+  }, []);
+
+  const handleBookmarkClick = (id: Number) => {
+    setPosts(
+      posts.map((post: Post) =>
+        post.id === id ? { ...post, isBookmarked: !post.isBookmarked } : post
+      )
+    );
+  };
+
+  return (
+    <Container maxWidth="xl">
+      {posts.length !== 0 && (
+        <PostList posts={posts} handleBookmarkClick={handleBookmarkClick} />
+      )}
+    </Container>
+  );
+}
+
+export default ListPage;

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -1,0 +1,8 @@
+export interface Post {
+  id: Number;
+  category: string;
+  title: string;
+  fullAddress: string;
+  thumbnail: string;
+  isBookmarked: boolean;
+}


### PR DESCRIPTION
## 개요
PostList 및 PostCard 컴포넌트 UI를 구현했습니다.

## 작업사항
- PostList 컴포넌트에 데이터를 내리면 PostCard를 목록 형태로 볼 수 있음 +) 반응형
- 주소 복사 기능
- 북마크 토글 기능

### 세부 설명
- 게시글 목록 화면의 라우팅을 뭐라고 할 지 정해지지 않아 일단 `/list`와 `<ListPage>`라고 이름 지었습니다.
- PostCard에게 내려줄 post 데이터의 타입을 재사용할 수 있도록 `types/post.ts` 안에  지정했습니다.
  - 나중에 게시글 상세조회 페이지에서 사용될 post 데이터 타입을 Post라고 하고, PostCard에 사용될 데이터는 Utility 타입으로 일부를 Pick해서 PostCard라고 다시 명명해도 될 것 같습니다.
- 북마크 토글 함수는 posts 상태를 변경하기 위해 같은 레벨인 ListPage에 작성해주었는데요, redux로 post 데이터를 관리하게 된다면 이 함수를 북마크 아이콘 내부로 옮기면 될 것 같습니다.